### PR TITLE
fix: disable litestream ruby puma plugin

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -38,7 +38,7 @@ plugin :tmp_restart
 # Run the Solid Queue supervisor inside of Puma for single-server deployments
 plugin :solid_queue if ENV['SOLID_QUEUE_IN_PUMA']
 
-plugin :litestream if %w[production staging review].include?(ENV.fetch('RAILS_ENV', 'production'))
+# plugin :litestream if %w[production staging review].include?(ENV.fetch('RAILS_ENV', 'production'))
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.


### PR DESCRIPTION
closes #116